### PR TITLE
conjugate vectors; length of complex vectors

### DIFF
--- a/lib/Math/Vector.pm
+++ b/lib/Math/Vector.pm
@@ -46,9 +46,14 @@ class Math::Vector
         $a ⋅ $b;
     }
 
+    method conjugate()
+    {
+      return Math::Vector.new(@.coordinates>>.conjugate);
+    }
+
     method Length()
     {
-        sqrt(self ⋅ self);
+        sqrt(self ⋅ self.conjugate).abs;
     }
     
     multi method abs()

--- a/t/01-basics.t
+++ b/t/01-basics.t
@@ -207,4 +207,7 @@ isa_ok($vl, Math::VectorWithLength, "Variable is of type Math::VectorWithLength"
 my $vlc = eval($vl.perl);
 isa_ok($vlc, Math::VectorWithLength, "eval'd perl'd variable is of type Math::VectorWithLength");
 
+my $complex_vector = Math::Vector.new(0, 3+4i);
+is($complex_vector.abs, 5, "length of vector with complex vector is real");
+
 done;


### PR DESCRIPTION
Added .conjugate method to the Vector class;

Length of a vector is the dot product of itself with its conjugate -- needed sqrt.abs to get rid of the +0i in the result.
